### PR TITLE
Manually enable cross-compilation on linux_aarch64

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,14 @@ jobs:
         CONFIG: linux_64_ogre1.12
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_ogre1.10:
+        CONFIG: linux_aarch64_ogre1.10
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_ogre1.12:
+        CONFIG: linux_aarch64_ogre1.12
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_aarch64_ogre1.10.yaml
+++ b/.ci_support/linux_aarch64_ogre1.10.yaml
@@ -1,0 +1,33 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.21'
+ogre:
+- '1.10'
+qt_main:
+- '5.15'
+target_platform:
+- linux-aarch64
+tinyxml2:
+- '9'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_ogre1.12.yaml
+++ b/.ci_support/linux_aarch64_ogre1.12.yaml
@@ -1,0 +1,33 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.21'
+ogre:
+- '1.12'
+qt_main:
+- '5.15'
+target_platform:
+- linux-aarch64
+tinyxml2:
+- '9'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_ogre1.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17652&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-gui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_ogre1.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_ogre1.12</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17652&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-gui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_ogre1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_ogre1.10</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17652&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,9 +1,12 @@
 build_platform:
   osx_arm64: osx_64
+  linux_aarch64: linux_64
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
+provider:
+  linux_aarch64: default
 test: native_and_emulated


### PR DESCRIPTION
I did not waited for the arch migration as in any case the qt dependency is not available on ppc64le .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
