### PR TITLE
Backport relocatability fixes

### DIFF
--- a/recipe/552.patch
+++ b/recipe/552.patch
@@ -1,0 +1,281 @@
+From 87109ff2c1ddb4cfaac7cabf4ada09f9193ea20b Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Wed, 21 Jun 2023 13:29:38 +0200
+Subject: [PATCH] Add optional binary relocatability
+
+Signed-off-by: Silvio Traversaro <silvio.traversaro@iit.it>
+---
+ CMakeLists.txt                            |  6 +++-
+ include/gz/gui/CMakeLists.txt             |  9 +++++
+ include/gz/gui/InstallationDirectories.hh | 43 +++++++++++++++++++++++
+ include/gz/gui/config.hh.in               |  2 +-
+ src/Application.cc                        | 11 +++---
+ src/CMakeLists.txt                        |  4 +++
+ src/InstallationDirectories.cc            | 37 +++++++++++++++++++
+ src/plugins/CMakeLists.txt                |  4 ++-
+ test/integration/CMakeLists.txt           |  2 ++
+ test/performance/CMakeLists.txt           |  4 ++-
+ test/regression/CMakeLists.txt            |  4 ++-
+ 11 files changed, 116 insertions(+), 10 deletions(-)
+ create mode 100644 include/gz/gui/InstallationDirectories.hh
+ create mode 100644 src/InstallationDirectories.cc
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 62bb5c351..2d904096c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -91,8 +91,12 @@ gz_find_package (Qt5
+   PKGCONFIG "Qt5Core Qt5Quick Qt5QuickControls2 Qt5Widgets"
+ )
+ 
++set(GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR
++  ${GZ_LIB_INSTALL_DIR}/gz-${GZ_DESIGNATION}-${PROJECT_VERSION_MAJOR}/plugins
++)
++
+ set(GZ_GUI_PLUGIN_INSTALL_DIR
+-  ${CMAKE_INSTALL_PREFIX}/${GZ_LIB_INSTALL_DIR}/gz-${GZ_DESIGNATION}-${PROJECT_VERSION_MAJOR}/plugins
++  ${CMAKE_INSTALL_PREFIX}/${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}
+ )
+ 
+ #============================================================================
+diff --git a/include/gz/gui/CMakeLists.txt b/include/gz/gui/CMakeLists.txt
+index b3842959e..27db7054e 100644
+--- a/include/gz/gui/CMakeLists.txt
++++ b/include/gz/gui/CMakeLists.txt
+@@ -50,6 +50,15 @@ gz_create_core_library(SOURCES
+   ${headers_MOC}
+   ${resources_RCC}
+ )
++gz_add_get_install_prefix_impl(GET_INSTALL_PREFIX_FUNCTION gz::gui::getInstallPrefix
++                               GET_INSTALL_PREFIX_HEADER gz/gui/InstallationDirectories.hh
++                               OVERRIDE_INSTALL_PREFIX_ENV_VARIABLE GZ_GUI_INSTALL_PREFIX)
++
++set_property(
++  SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/InstallationDirectories.cc
++  PROPERTY COMPILE_DEFINITIONS
++  GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR="${GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR}"
++)
+ 
+ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+   PUBLIC
+diff --git a/include/gz/gui/InstallationDirectories.hh b/include/gz/gui/InstallationDirectories.hh
+new file mode 100644
+index 000000000..5dcbe44f1
+--- /dev/null
++++ b/include/gz/gui/InstallationDirectories.hh
+@@ -0,0 +1,43 @@
++/*
++ * Copyright (C) 2023 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#ifndef GZ_GUI_INSTALLATION_DIRECTORIES_HH_
++#define GZ_GUI_INSTALLATION_DIRECTORIES_HH_
++
++#include <string>
++
++#include <gz/gui/config.hh>
++#include <gz/gui/Export.hh>
++
++namespace gz
++{
++  namespace gui
++  {
++    inline namespace GZ_GUI_VERSION_NAMESPACE {
++
++    /// \brief getInstallPrefix return the install prefix of the library
++    /// i.e. CMAKE_INSTALL_PREFIX unless the library has been moved
++    GZ_GUI_VISIBLE std::string getInstallPrefix();
++
++    /// \brief getPluginInstallDir return the install directory of the plugins
++    GZ_GUI_VISIBLE std::string getPluginInstallDir();
++
++    }
++  }
++}
++
++#endif
+diff --git a/include/gz/gui/config.hh.in b/include/gz/gui/config.hh.in
+index 6737ef44b..dc0c333f1 100644
+--- a/include/gz/gui/config.hh.in
++++ b/include/gz/gui/config.hh.in
+@@ -30,6 +30,6 @@
+ 
+ #define GZ_GUI_VERSION_HEADER "Gazebo GUI, version ${PROJECT_VERSION_FULL}\nCopyright (C) 2017 Open Source Robotics Foundation.\nReleased under the Apache 2.0 License.\n\n"
+ 
+-#define GZ_GUI_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${GZ_LIB_INSTALL_DIR}/gz-${GZ_DESIGNATION}-${PROJECT_VERSION_MAJOR}/plugins"
++#define GZ_GUI_PLUGIN_INSTALL_DIR _Pragma ("GCC warning \"'GZ_GUI_PLUGIN_INSTALL_DIR' macro is deprecated, use gz::gui::getPluginInstallDir() function instead. \"") "${GZ_GUI_PLUGIN_INSTALL_DIR}"
+ 
+ #endif
+diff --git a/src/Application.cc b/src/Application.cc
+index eb63208b9..22a81db9c 100644
+--- a/src/Application.cc
++++ b/src/Application.cc
+@@ -31,6 +31,7 @@
+ #include "gz/gui/config.hh"
+ #include "gz/gui/Dialog.hh"
+ #include "gz/gui/Helpers.hh"
++#include "gz/gui/InstallationDirectories.hh"
+ #include "gz/gui/MainWindow.hh"
+ #include "gz/gui/Plugin.hh"
+ 
+@@ -467,12 +468,12 @@ bool Application::LoadPlugin(const std::string &_filename,
+   // Add default folder and install folder
+   std::string home;
+   common::env(GZ_HOMEDIR, home);
+-  systemPaths.AddPluginPaths(home + "/.gz/gui/plugins:" +
+-                             GZ_GUI_PLUGIN_INSTALL_DIR);
++  systemPaths.AddPluginPaths(home + "/.gz/gui/plugins");
++  systemPaths.AddPluginPaths(gz::gui::getPluginInstallDir());
+ 
+   // TODO(CH3): Deprecated. Remove on tock.
+-  systemPaths.AddPluginPaths(home + "/.ignition/gui/plugins:" +
+-                             GZ_GUI_PLUGIN_INSTALL_DIR);
++  systemPaths.AddPluginPaths(home + "/.ignition/gui/plugins");
++  systemPaths.AddPluginPaths(gz::gui::getPluginInstallDir());
+ 
+ 
+   auto pathToLib = systemPaths.FindSharedLibrary(_filename);
+@@ -782,7 +783,7 @@ std::vector<std::pair<std::string, std::vector<std::string>>>
+   paths.push_back(home + "/.ignition/gui/plugins");
+ 
+   // 4. Install path
+-  paths.push_back(GZ_GUI_PLUGIN_INSTALL_DIR);
++  paths.push_back(gz::gui::getPluginInstallDir());
+ 
+   // Populate map
+   std::vector<std::pair<std::string, std::vector<std::string>>> plugins;
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f931ec64b..0ff59bd90 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -8,6 +8,7 @@ set (sources
+   ${CMAKE_CURRENT_SOURCE_DIR}/GuiEvents.cc
+   ${CMAKE_CURRENT_SOURCE_DIR}/Helpers.cc
+   ${CMAKE_CURRENT_SOURCE_DIR}/gz.cc
++  ${CMAKE_CURRENT_SOURCE_DIR}/InstallationDirectories.cc
+   ${CMAKE_CURRENT_SOURCE_DIR}/MainWindow.cc
+   ${CMAKE_CURRENT_SOURCE_DIR}/PlottingInterface.cc
+   ${CMAKE_CURRENT_SOURCE_DIR}/Plugin.cc
+@@ -53,6 +54,8 @@ gz_build_tests(TYPE UNIT
+                   TINYXML2::TINYXML2
+                 TEST_LIST
+                   gtest_targets
++                ENVIRONMENT 
++                  GZ_GUI_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+ )
+ 
+ foreach(test ${gtest_targets})
+@@ -76,6 +79,7 @@ if(TARGET UNIT_gz_TEST)
+ 
+   set(_env_vars)
+   list(APPEND _env_vars "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf")
++  list(APPEND _env_vars "GZ_GUI_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
+ 
+   set_tests_properties(UNIT_gz_TEST PROPERTIES
+     ENVIRONMENT "${_env_vars}")
+diff --git a/src/InstallationDirectories.cc b/src/InstallationDirectories.cc
+new file mode 100644
+index 000000000..5963a3f47
+--- /dev/null
++++ b/src/InstallationDirectories.cc
+@@ -0,0 +1,37 @@
++/*
++ * Copyright (C) 2023 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++*/
++
++#include <gz/gui/config.hh>
++#include <gz/gui/InstallationDirectories.hh>
++
++#include <gz/common/Filesystem.hh>
++
++namespace gz
++{
++namespace gui
++{
++inline namespace GZ_GUI_VERSION_NAMESPACE {
++
++std::string getPluginInstallDir()
++{
++  return gz::common::joinPaths(
++      getInstallPrefix(), GZ_GUI_PLUGIN_RELATIVE_INSTALL_DIR);
++}
++
++}
++}
++}
+\ No newline at end of file
+diff --git a/src/plugins/CMakeLists.txt b/src/plugins/CMakeLists.txt
+index 36ede3212..3f40148e9 100644
+--- a/src/plugins/CMakeLists.txt
++++ b/src/plugins/CMakeLists.txt
+@@ -93,7 +93,9 @@ function(gz_gui_add_plugin plugin_name)
+         # Used to make test-directory headers visible to the unit tests
+         ${PROJECT_SOURCE_DIR}
+         # Used to make test_config.h visible to the unit tests
+-        ${PROJECT_BINARY_DIR})
++        ${PROJECT_BINARY_DIR}
++      ENVIRONMENT 
++        GZ_GUI_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+   endif()
+ 
+   if (MSVC)
+diff --git a/test/integration/CMakeLists.txt b/test/integration/CMakeLists.txt
+index 55170ef0c..70c2ff1e5 100644
+--- a/test/integration/CMakeLists.txt
++++ b/test/integration/CMakeLists.txt
+@@ -10,4 +10,6 @@ gz_build_tests(
+     gz-plugin${GZ_PLUGIN_VER}::loader
+     gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
+     Qt5::Test
++  ENVIRONMENT 
++    GZ_GUI_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+ )
+diff --git a/test/performance/CMakeLists.txt b/test/performance/CMakeLists.txt
+index 0a11145ce..20a472318 100644
+--- a/test/performance/CMakeLists.txt
++++ b/test/performance/CMakeLists.txt
+@@ -1,3 +1,5 @@
+ gz_get_sources(tests)
+ 
+-gz_build_tests(TYPE PERFORMANCE SOURCES ${tests})
++gz_build_tests(TYPE PERFORMANCE
++               SOURCES ${tests}
++               ENVIRONMENT GZ_GUI_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+diff --git a/test/regression/CMakeLists.txt b/test/regression/CMakeLists.txt
+index 762a05202..24686b690 100644
+--- a/test/regression/CMakeLists.txt
++++ b/test/regression/CMakeLists.txt
+@@ -1,3 +1,5 @@
+ gz_get_sources(tests)
+ 
+-gz_build_tests(TYPE REGRESSION SOURCES ${tests})
++gz_build_tests(TYPE REGRESSION 
++               SOURCES ${tests}
++               ENVIRONMENT GZ_GUI_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+

--- a/recipe/bld_cxx.bat
+++ b/recipe/bld_cxx.bat
@@ -11,6 +11,7 @@ cmake ^
     -DCMAKE_INSTALL_LIBDIR=lib ^
     -DBUILD_SHARED_LIBS=ON ^
     -DBUILD_TESTING=ON ^
+    -DGZ_ENABLE_RELOCATABLE_INSTALL:BOOL=ON ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/build_cxx.sh
+++ b/recipe/build_cxx.sh
@@ -17,6 +17,7 @@ cmake ${CMAKE_ARGS} -GNinja \
       -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_TESTING=OFF \
+      -DGZ_ENABLE_RELOCATABLE_INSTALL:BOOL=ON ^\
       ..
 
 cmake --build . --config Release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,10 @@ source:
     sha256: 735ad5826fd8e40244ce9ac92f6600676f6b64e58ca9d7c021131467018f4584
     patches:
       - 544.patch
+      - 552.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
As merging https://github.com/gazebosim/gz-gui/pull/552 upstream will take some time, let's backport the patch here. While this indeed introduces some new ABI symbols, if the symbols ends being changed in the upstream release, we can always re-introduce them with a custom patch, if that turns out to be necessary.

Similar to https://github.com/conda-forge/gz-physics-feedstock/pull/11 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
